### PR TITLE
Ensure resources have not already been consumed

### DIFF
--- a/Assets/Scripts/Core/GameManager.cs
+++ b/Assets/Scripts/Core/GameManager.cs
@@ -65,6 +65,7 @@ public class GameManager : Singleton<GameManager> {
     public void ConsumeResource(GameResource resource)
     {
 		interactionComponent.InventoryComponent.DropHeld(resource);
+        resource.State = GameResource.ResourceState.Consumed;
         resource.gameObject.SetActive(false);
     }
 
@@ -124,7 +125,7 @@ public class GameManager : Singleton<GameManager> {
 		foreach(IInteractable interact in Interactables[(int)InteractableType.PICKUP])
         {
             GameResource gr = interact as GameResource; // Try and cast down the tree to a GameResource
-			if (gr != null && ((IHoldable)gr).HeldState != HoldState.Held && Vector3.Distance(gr.transform.position, t.position) <= range)
+			if (gr != null && ((IHoldable)gr).HeldState != HoldState.Held && Vector3.Distance(gr.transform.position, t.position) <= range && gr.State == GameResource.ResourceState.Ready)
             {   // This interactable was a resource, and is close enough to be included
                 ret.Add(gr);
             }

--- a/Assets/Scripts/Resource/ResourceSpawner.cs
+++ b/Assets/Scripts/Resource/ResourceSpawner.cs
@@ -75,6 +75,11 @@ public class ResourceSpawner : MonoBehaviour {
 		resourceIsSpawned = true;
         resourceInstance.SetActive(true);
         resourceInstance.transform.position = transform.TransformPoint(spawnPosition);
+        GameResource resourceComponent = resourceInstance.GetComponent<GameResource>();
+        if(resourceComponent != null)
+        {
+            resourceComponent.State = GameResource.ResourceState.Ready;
+        }
         if (animator != null)
         {
             animator.SetBool(ANIMATOR_HAS_RESOURCE_TAG, true);


### PR DESCRIPTION
Don't allow consumed resources to be considered for repair, and make sure they are consumed and replentished during lifecycle